### PR TITLE
Profession Skill Points

### DIFF
--- a/HandyNotes_DragonflightTreasures.toc
+++ b/HandyNotes_DragonflightTreasures.toc
@@ -32,3 +32,12 @@ shared\ExpeditionScoutsPack.lua
 achievements\HighestPeaks.lua
 achievements\DragonGlyphs.lua
 achievements\Races.lua
+
+profession_knowledge\Alchemy.lua
+profession_knowledge\Blacksmithing.lua
+profession_knowledge\Enchanting.lua
+profession_knowledge\Engineering.lua
+profession_knowledge\Inscription.lua
+profession_knowledge\Jewelcrafting.lua
+profession_knowledge\Leatherworking.lua
+profession_knowledge\Tailoring.lua

--- a/dragonflight.lua
+++ b/dragonflight.lua
@@ -14,6 +14,16 @@ ns.FACTION_DRAGONSCALE = 2507
 ns.MAXLEVEL = {ns.conditions.QuestComplete(67030), ns.conditions.Level(70)}
 ns.DRAGONRIDING = ns.conditions.SpellKnown(376777)
 
+-- Dragonflight Professions (used for profession knowledge)
+ns.PROF_DF_ALCHEMY = ns.conditions.SpellKnown(366261) -- Dragon Isles Alchemy
+ns.PROF_DF_BLACKSMITHING = ns.conditions.SpellKnown(365677) -- Dragon Isles Blacksmithing
+ns.PROF_DF_ENCHANTING = ns.conditions.SpellKnown(366255) -- Dragon Isles Enchanting
+ns.PROF_DF_ENGINEERING = ns.conditions.SpellKnown(366254) -- Dragon Isles Engineering
+ns.PROF_DF_INSCRIPTION = ns.conditions.SpellKnown(366251) -- Dragon Isles Inscription
+ns.PROF_DF_JEWELCRAFTING = ns.conditions.SpellKnown(366250) -- Dragon Isles Jewelcrafting
+ns.PROF_DF_LEATHERWORKING = ns.conditions.SpellKnown(366249) -- Dragon Isles Leatherworking
+ns.PROF_DF_TAILORING = ns.conditions.SpellKnown(366258) -- Dragon Isles Tailoring
+
 ns.hiddenConfig = {
     groupsHidden = true,
 }
@@ -30,6 +40,7 @@ ns.groups["scoutpack"] = "Expedition Scout's Pack"
 ns.groups["glyphs"] = "Dragon Glyphs"
 ns.groups["dailymount"] = "Daily Mounts"
 ns.groups["races"] = "{achievement:15939:Dragon Racing Completionist}"
+ns.groups["professionknowledge"] = "Profession Knowledge Points"
 
 -- Intro:
 -- Talked to Azurathel: 72285

--- a/profession_knowledge/Alchemy.lua
+++ b/profession_knowledge/Alchemy.lua
@@ -1,0 +1,70 @@
+local myname, ns = ...
+
+local dfalcknowledge = {
+    label = "Alchemist's Knowledge",
+	note= "This can only be looted once per character.",
+    requires = ns.PROF_DF_ALCHEMY,
+    group = "professionknowledge",
+	minimap = true,
+}
+-- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
+ns.RegisterPoints(ns.WAKINGSHORES, {
+    [25107330] = {
+		note = "Dragonbane Keep, near the entrance to the event boss. Collectible mug is between a lot of elite trash.",
+		loot = {
+			198685, -- Well Insulated Mug
+		},
+		quest = nil,
+	},
+    [55008100] = {
+		note = "Middle of the Icy Crater",
+		loot = {
+			198663, -- Frostforged Potion
+		},
+		quest = nil,
+	},
+}, dfalcknowledge)
+
+ns.RegisterPoints(ns.OHNAHRANPLAINS, {
+    [79208380] = {
+		note = "Deep inside cave SE of Forkriver Crossing. It's in a bottle near a dead Expedition Scout in the water.",
+		loot = {
+			198710, -- Canteen of Suspicious Water
+		},
+		quest = nil,
+	},
+}, dfalcknowledge)
+
+ns.RegisterPoints(ns.AZURESPAN, {
+    [16403850] = {
+		note = "North of Iskaara inside a large green cauldron between gnoll trash.",
+		loot = {
+			198599, -- Experimental Decay Sample
+		},
+		quest = nil,
+	},
+    [67001320] = {
+		note = "Outside Timbermaw log house next to vase.",
+		loot = {
+			198712, -- Firewater Power Sample
+		},
+		quest = nil,
+	},
+}, dfalcknowledge)
+
+ns.RegisterPoints(ns.THALDRASZUS, {
+    [55203050] = {
+		note = "Under a rock overhang. Marked as Mysterious Cauldron. There are 3 cauldrons and you need to drop a nearby docile dub on each on each. May explode or spawn an Expanded Angry Cub.",
+		loot = {
+			201003, -- Furry Gloop
+		},
+		quest = nil,
+	},
+    [59503840] = {
+		note = "Small purple glowing potion, hidden in bushes. Difficult to see.",
+		loot = {
+			198697, -- Contraband Concoction
+		},
+		quest = nil,
+	},
+}, dfalcknowledge)

--- a/profession_knowledge/Blacksmithing.lua
+++ b/profession_knowledge/Blacksmithing.lua
@@ -1,0 +1,78 @@
+local myname, ns = ...
+
+local dfbsknowledge = {
+    label = "Blacksmith's Knowledge",
+	note= "This can only be looted once per character.",
+    requires = ns.PROF_DF_BLACKSMITHING,
+    group = "professionknowledge",
+	minimap = true,
+}
+-- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
+ns.RegisterPoints(ns.WAKINGSHORES, {
+    [22008700] = {
+		note = "Apex Canopy; four yellow Enchanted Bulwarks surrounding a sword on a pedestal.",
+		loot = {
+			201007, -- Ancient Monument
+		},
+		quest = nil,
+	},
+    [65502570] = {
+		note = "Scalecracker Keep, ingot on the ground near a big hut next to a forge.",
+		loot = {
+			201005, -- Curious Ingots
+		},
+		quest = nil,
+	},
+    [35506430] = {
+		note = "West of Obsidian Bulwark by a lava river, near a fishing trainer. Kick 3 ingots into the lava to spawn a mob. Chest that spawns afterward contains the item. Just north of {item:201010:Qalashi Weapon Diagram}.",
+		loot = {
+			201008, -- Molton Ingot
+		},
+		quest = nil,
+	},
+    [34506701] = {
+		note = "West of Obsidian Bulwark in an island surrounded by lava, on top of an anvil. Just south of {item:201008:Molten Ingot}.",
+		loot = {
+			201010, -- Qalashi Weapon Diagram
+		},
+		quest = nil,
+	},
+}, dfbsknowledge)
+
+ns.RegisterPoints(ns.OHNAHRANPLAINS, {
+    [81103790] = {
+		note = "Inside a cave west of Rusza'thar Reach. Cave inhabited by neutral Shale Giants",
+		loot = {
+			201004, -- Ancient Spear Shards
+		},
+		path = 79403650,
+		quest = nil,
+	},
+    [50906650] = {
+		note = "Island in the sea, inside a hut.",
+		loot = {
+			201009, -- Falconer Gauntlet Drawings
+		},
+		quest = nil,
+	},
+}, dfbsknowledge)
+
+ns.RegisterPoints(ns.AZURESPAN, {
+    [53106530] = {
+		note = "Azure Archives, inside a small cave. Blocked by a Rock Wall, so you will need to be a miner or get one to help you open the wall.",
+		loot = {
+			201011, -- Spelltouched Tongs
+		},
+		quest = nil,
+	},
+}, dfbsknowledge)
+
+ns.RegisterPoints(ns.THALDRASZUS, {
+    [52208050] = {
+		note = "Shifting Sands, west of the Shifting Sands flightpoint. Inside a building, a bit high up.",
+		loot = {
+			201006, -- Draconic Flux
+		},
+		quest = nil,
+	},
+}, dfbsknowledge)

--- a/profession_knowledge/Enchanting.lua
+++ b/profession_knowledge/Enchanting.lua
@@ -1,0 +1,77 @@
+local myname, ns = ...
+
+local dfenchknowledge = {
+    label = "Enchanter's Knowledge",
+	note= "This can only be looted once per character.",
+    requires = ns.PROF_DF_ENCHANTING,
+    group = "professionknowledge",
+	minimap = true,
+}
+-- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
+ns.RegisterPoints(ns.WAKINGSHORES, {
+    [57508360] = {
+		note = "Flashfrozen Enclave, in frozen cave system.",
+		loot = {
+			198798, -- Flashfrozen Scroll
+		},
+		quest = nil,
+	},
+    [68002680] = {
+		note = "Scalecracker Keep, next to a lava flower in a flower.",
+		loot = {
+			198675, -- Lava-Infused Seed
+		},
+		quest = nil,
+	},
+    [57505850] = {
+		note = "Use Disenchanted Broom and follow Enchanted Broom, then loot the debris at path's end.",
+		loot = {
+			201012, -- Enchanted Debris
+		},
+		quest = nil,
+	},
+}, dfenchknowledge)
+
+ns.RegisterPoints(ns.OHNAHRANPLAINS, {
+    [61406760] = {
+		note = "Windsong Rise, north of Ohn'iri Springsr.",
+		loot = {
+			198689, -- Stormbound Horn
+		},
+		quest = nil,
+	},
+}, dfenchknowledge)
+
+ns.RegisterPoints(ns.AZURESPAN, {
+    [38505920] = {
+		note = "Azure Archives, in a leveled tomb with a rare mob on the NW side. Tome is lying on the floor to the right of the entrance.",
+		loot = {
+			198799, -- Forgotten Arcane Tome
+		},
+		quest = nil,
+	},
+    [45216114] = {
+		note = "Just east of Azure Archives. Click on Mana-Starved Crystal Cluster to spawn a mob. Kill the mob and click the crystal that spawns.",
+		loot = {
+			201013, -- Faintly Enchanted Remains
+		},
+		quest = nil,
+	},
+    [21004500] = {
+		note = "Inside the mountain.", -- Need info on how to access it!
+		loot = {
+			198694, -- Enriched Earthen Shard
+		},
+		quest = nil,
+	},
+}, dfenchknowledge)
+
+ns.RegisterPoints(ns.THALDRASZUS, {
+    [59907040] = {
+		note = "South of Tyrhold.",
+		loot = {
+			198800, -- Fractured Titanic Sphere
+		},
+		quest = nil,
+	},
+}, dfenchknowledge)

--- a/profession_knowledge/Engineering.lua
+++ b/profession_knowledge/Engineering.lua
@@ -1,0 +1,62 @@
+local myname, ns = ...
+
+local dfengknowledge = {
+    label = "Engineer's Knowledge",
+	note= "This can only be looted once per character.",
+    requires = ns.PROF_DF_ENGINEERING,
+    group = "professionknowledge",
+	minimap = true,
+}
+-- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
+ns.RegisterPoints(ns.WAKINGSHORES, {
+    [56004490] = {
+		note = "Concord Observatory, north of Ruby Life Pools flight point, high up with pillar-like buildings. Need to pick up 4 different items to loot the rocket. Ashes are in the same building; other 3 items are in the bigger building across the open area.",
+		loot = {
+			201014, -- Boomthyr Rocket
+		},
+		quest = nil,
+		related = {
+			[56054494] = {
+			label = "Note on the floor.",
+			note = "Read this first!",
+			},
+			[55924519] = {
+			label = "{item:198815:Ash}",
+			},
+			[57844446] = {
+			label = "Look for {item:198814:Boom Fumes}/{item:198817:Durable Crystal}/{item:198816:Aerospace Grade Draconium} around this area.",
+			},
+		},
+	},
+}, dfengknowledge)
+--[[
+ns.RegisterPoints(ns.OHNAHRANPLAINS, {
+    [] = {
+		note = "",
+		loot = {
+			, -- 
+		},
+		quest = nil,
+	},
+}, dfengknowledge)
+
+ns.RegisterPoints(ns.AZURESPAN, {
+    [] = {
+		note = "",
+		loot = {
+			, -- 
+		},
+		quest = nil,
+	},
+}, dfengknowledge)
+
+ns.RegisterPoints(ns.THALDRASZUS, {
+    [] = {
+		note = "",
+		loot = {
+			, -- 
+		},
+		quest = nil,
+	},
+}, dfengknowledge)
+]]

--- a/profession_knowledge/Inscription.lua
+++ b/profession_knowledge/Inscription.lua
@@ -10,7 +10,7 @@ local dfinsknowledge = {
 -- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
 ns.RegisterPoints(ns.WAKINGSHORES, {
     [67905800] = {
-		note = "Behind a small stone tablebehind a small stone table. Maybe???",
+		note = "Behind a small stone table behind a small stone table. Loot this before looting the {item:198669:How to Train Your Whelpling} item due to a possible bug!",
 		loot = {
 			198704, -- Pulsing Earth Rune
 		},
@@ -71,7 +71,7 @@ ns.RegisterPoints(ns.THALDRASZUS, {
 
 ns.RegisterPoints(ns.VALDRAKKEN, {
     [13206368] = {
-		note = "Little Scales Day Care area, brown book lying in the sandbox. Don't ask how it got there.",
+		note = "Little Scales Day Care area, brown book lying in the sandbox.\nLoot the {item:198704:Pulsing Earth Rune} before looting this due to a possible bug!",
 		loot = {
 			198669, -- How to Train Your Whelpling
 		},

--- a/profession_knowledge/Inscription.lua
+++ b/profession_knowledge/Inscription.lua
@@ -1,0 +1,80 @@
+local myname, ns = ...
+
+local dfinsknowledge = {
+    label = "Inscriptionist's Knowledge",
+	note= "This can only be looted once per character.",
+    requires = ns.PROF_DF_INSCRIPTION,
+    group = "professionknowledge",
+	minimap = true,
+}
+-- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
+ns.RegisterPoints(ns.WAKINGSHORES, {
+    [67905800] = {
+		note = "Behind a small stone tablebehind a small stone table. Maybe???",
+		loot = {
+			198704, -- Pulsing Earth Rune
+		},
+		quest = nil,
+	},
+}, dfinsknowledge)
+
+ns.RegisterPoints(ns.OHNAHRANPLAINS, {
+    [85702520] = {
+		note = "Timberstep Outpost, hanging on tent entrance.",
+		loot = {
+			198703, -- Sign Language Reference Sheet
+		},
+		quest = nil,
+	},
+}, dfinsknowledge)
+
+ns.RegisterPoints(ns.AZURESPAN, {
+    [46202390] = {
+		note = "Cobalt Assembly, inside a building on an upper level.",
+		loot = {
+			198693, -- Dusty Darkmoon Card
+		},
+		quest = nil,
+	},
+    [43703090] = {
+		note = "Behind an Arcane Commander.",
+		loot = {
+			198686, -- Frosted Parchment
+		},
+		quest = nil,
+	},
+}, dfinsknowledge)
+
+ns.RegisterPoints(ns.THALDRASZUS, {
+    [56304120] = {
+		note = "West of Algeth'ar Academy entrance, on a table near a big telescope. Tome #1",
+		loot = {
+			198659, -- Forgetful Apprentice's Tome #1
+		},
+		quest = nil,
+	},
+    [47244010] = {
+		note = "Above Algeth'era FP, just west in a small building. Interactable {item:380584:Curious Glyph} inside. Click and phase, cross the bridge with some 70 mobs, and kill the neutral mob inside the house. Deliver its dropped item to the glyph to get the item. Tome #2",
+		loot = {
+			198659, -- Forgetful Apprentice's Tome #2
+		},
+		quest = nil,
+	},
+    [56104090] = {
+		note = "Speak to {npc:194856:Siennagosa}. Offer to help set back her Darkmoon Deck. Scattered at her feet are 8 Darkmoon cards. Click them in the correct order (Ace through 8). Speak to her afterward to get the deck.",
+		loot = {
+			201015, -- Counterfit Darkmoon Deck
+		},
+		quest = nil,
+	},
+}, dfinsknowledge)
+
+ns.RegisterPoints(ns.VALDRAKKEN, {
+    [13206368] = {
+		note = "Little Scales Day Care area, brown book lying in the sandbox. Don't ask how it got there.",
+		loot = {
+			198669, -- How to Train Your Whelpling
+		},
+		quest = nil,
+	},
+}, dfinsknowledge)

--- a/profession_knowledge/Jewelcrafting.lua
+++ b/profession_knowledge/Jewelcrafting.lua
@@ -1,0 +1,79 @@
+local myname, ns = ...
+
+local dfjcknowledge = {
+    label = "Jewelcrafter's Knowledge",
+	note= "This can only be looted once per character.",
+    requires = ns.PROF_DF_JEWELCRAFTING,
+    group = "professionknowledge",
+	minimap = true,
+}
+-- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
+ns.RegisterPoints(ns.WAKINGSHORES, {
+    [50404510] = {
+		note = "Right before a waterfall, look for a beaver's nest. Underneath the tree cover next to the nest is a blue gem.",
+		loot = {
+			198687, -- Closely Guarded Shiny
+		},
+		quest = 70292,
+	},
+    [33966366] = {
+		note = "Dragonbane Keep, locked behind a minigame. Click 3 different crystals on small islands inside the magma. Kill the big magma frog jumping around before you do this. After clicking the first one, you only have a limited time to click the other two. Once all 3 are channeling, the item is unlocked.",
+		loot = {
+			201017, -- Igneous Gem
+		},
+		quest = 70273,
+	},
+}, dfjcknowledge)
+
+ns.RegisterPoints(ns.OHNAHRANPLAINS, {
+    [25203540] = {
+		note = "Storm Scar, inside a cave, floating in the air.",
+		loot = {
+			198670, -- Lofty Malygite
+		},
+		quest = nil,
+	},
+    [61771302] = {
+		note = "Neltharan Plains, crumbled building with a tree growing inside. Look for it under the tree's roots. Comes with a bonus treasure.",
+		loot = {
+			198660, -- Fragmented Key
+		},
+		quest = 70263,
+	},
+}, dfjcknowledge)
+
+ns.RegisterPoints(ns.AZURESPAN, {
+    [45006130] = {
+		note = "Azure Archives, next to a small pond/starting point of a river.",
+		loot = {
+			198664, -- Crystalline Overgrowth
+		},
+		quest = nil,
+	},
+    [44606120] = {
+		note = "Azure Archives, locked behind a minigame. There is a chest inside the pond with a large silver key. Click it to receive a buff. While buff is active, click 3 nearby crystals.",
+		loot = {
+			201016, -- Harmonic Crystal Harmonizer
+		},
+		quest = nil,
+	},
+	--[[ -- Wrong location. This is for the inscription Frosted Parchment item.
+    [43703090] = {
+		note = "Behind an Arcane Commander",
+		loot = {
+			198656, -- Painter's Pretty Jewel
+		},
+		quest = nil,
+	},
+	]]
+}, dfjcknowledge)
+
+ns.RegisterPoints(ns.THALDRASZUS, {
+    [59856523] = {
+		note = "Tyrhold, right at the base of the letter 'T' on the map.",
+		loot = {
+			198682, -- Alexstraszite Cluster
+		},
+		quest = 70285,
+	},
+}, dfjcknowledge)

--- a/profession_knowledge/Jewelcrafting.lua
+++ b/profession_knowledge/Jewelcrafting.lua
@@ -57,15 +57,6 @@ ns.RegisterPoints(ns.AZURESPAN, {
 		},
 		quest = nil,
 	},
-	--[[ -- Wrong location. This is for the inscription Frosted Parchment item.
-    [43703090] = {
-		note = "Behind an Arcane Commander",
-		loot = {
-			198656, -- Painter's Pretty Jewel
-		},
-		quest = nil,
-	},
-	]]
 }, dfjcknowledge)
 
 ns.RegisterPoints(ns.THALDRASZUS, {
@@ -75,5 +66,12 @@ ns.RegisterPoints(ns.THALDRASZUS, {
 			198682, -- Alexstraszite Cluster
 		},
 		quest = 70285,
+	},
+    [56914372] = {
+		note = "Inside the lantern.",
+		loot = {
+			198656, -- Painter's Pretty Jewel
+		},
+		quest = nil,
 	},
 }, dfjcknowledge)

--- a/profession_knowledge/Leatherworking.lua
+++ b/profession_knowledge/Leatherworking.lua
@@ -1,0 +1,70 @@
+local myname, ns = ...
+
+local dflwknowledge = {
+    label = "Leatherworker's Knowledge",
+	note= "This can only be looted once per character.",
+    requires = ns.PROF_DF_LEATHERWORKING,
+    group = "professionknowledge",
+	minimap = true,
+}
+-- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
+ns.RegisterPoints(ns.WAKINGSHORES, {
+    [39008600] = {
+		note = "Next to a dead Vulpera laying beside the riverbed.",
+		loot = {
+			198711, -- Poacher's Pack
+		},
+		quest = nil,
+	},
+    [64302540] = {
+		note = "Lying next to dead red dragon.",
+		loot = {
+			198667, -- Spare Djardin Tools
+		},
+		quest = nil,
+	},
+}, dflwknowledge)
+
+ns.RegisterPoints(ns.OHNAHRANPLAINS, {
+    [86405370] = {
+		note = "Inside Shikaar Highlands Centaur camp.",
+		loot = {
+			198696, -- Wind-Blessed Hide
+		},
+		quest = nil,
+	},
+}, dflwknowledge)
+
+ns.RegisterPoints(ns.AZURESPAN, {
+    [12504940] = {
+		note = "Iskaara, in an underground building with {npc:186446:Elder Nappa} and {npc:186448:Elder Poa}. Activate the treasure by fixing the {item:380573:Broken Drum} next to {npc:194862:Raq}. Once he dances on it, you can loot the item.",
+		loot = {
+			201018, -- Well-Danced Drum
+		},
+		quest = nil,
+	},
+    [16703880] = {
+		note = "North of Iskaara, in the barrel in a gnoll camp.",
+		loot = {
+			198658, -- Decay-Infused Tanning Oil
+		},
+		quest = nil,
+	},
+    [57504130] = {
+		note = "Snowhide camp east of Camp Antonidas.",
+		loot = {
+			198683, -- Treated Hides
+		},
+		quest = nil,
+	},
+}, dflwknowledge)
+
+ns.RegisterPoints(ns.THALDRASZUS, {
+    [56803050] = {
+		note = "Inside a basket within the Fetid's camp.",
+		loot = {
+			198690, -- Decayed Scales
+		},
+		quest = nil,
+	},
+}, dflwknowledge)

--- a/profession_knowledge/Tailoring.lua
+++ b/profession_knowledge/Tailoring.lua
@@ -1,0 +1,77 @@
+local myname, ns = ...
+
+local dftlrknowledge = {
+    label = "Tailor's Knowledge",
+	note= "This can only be looted once per character.",
+    requires = ns.PROF_DF_TAILORING,
+    group = "professionknowledge",
+	minimap = true,
+}
+-- https://www.wowhead.com/guide/professions/knowledge-point-treasure-locations-dragon-isles
+ns.RegisterPoints(ns.WAKINGSHORES, {
+    [74703790] = {
+		note = "Wingrest Embassy, fluttering on top of one of the buildings a bit to the south.",
+		loot = {
+			198699, -- Mysterious Banner
+		},
+		quest = nil,
+	},
+    [24906970] = {
+		note = "Dragonbane Keep. When doing the Siege of Dragonbane Keep, this is just outside the cave where the end boss spawns. It's a piece of fabric hanging on a tree. Requires some precision Dragonriding or a warlock portal to reach.",
+		loot = {
+			198702, -- Itinerant Singed Fabric
+		},
+		quest = nil,
+	},
+}, dftlrknowledge)
+
+ns.RegisterPoints(ns.OHNAHRANPLAINS, {
+    [32203800] = {
+		note = "Nokhudon Hold. Sitting in a small hut on the floor right before entering the arena for the quest fight. 3 elites in the hut.",
+		loot = {
+			198692, -- Noteworthy Scrap of Carpet
+		},
+		quest = nil,
+	},
+    [66105290] = {
+		note = "Cleverwood Hollow. Use the {item:380599:Catnip Frond} and collect it.",
+		loot = {
+			201020, -- Silky Surprise
+		},
+		quest = nil,
+	},
+}, dftlrknowledge)
+
+ns.RegisterPoints(ns.AZURESPAN, {
+    [16203880] = {
+		note = "Brackenhide Hollow - Elite mob area. A red carpet hanging on a tree within a makeshift tent.",
+		loot = {
+			198680, -- Decaying Brackenhide Blanket
+		},
+		quest = nil,
+	},
+    [40705450] = {
+		note = "North of Azure Archives, in a small tower-like building full of mirror images of Kalecgos. Blue Cloth lying on the floor when you follow the stairs to the left.",
+		loot = {
+			198662, -- Intriguing Bolt of Blue Cloth
+		},
+		quest = nil,
+	},
+}, dftlrknowledge)
+
+ns.RegisterPoints(ns.THALDRASZUS, {
+    [60407970] = {
+		note = "Temporal Conflux, on the northeasteast platform -- small banner inside a pile of sand.",
+		loot = {
+			198684, -- Miniature Bronze Dragonflight Banner
+		},
+		quest = nil,
+	},
+    [58604580] = {
+		note = "Algeth'ar Academy, south of the dungeon portal, slightly on the left. {item:380763:Ancient Dragonweave Loom} is inside and starts a minigame where you connect the spools of thread to the center gem. Completing the game awards the item.",
+		loot = {
+			201019, -- Ancient Dragonweave Bolt
+		},
+		quest = nil,
+	},
+}, dftlrknowledge)

--- a/zones/Thaldraszus.lua
+++ b/zones/Thaldraszus.lua
@@ -57,16 +57,6 @@ ns.RegisterPoints(MAPID, {
     minimap=true,
     hide_before=ns.conditions.Level(64),
 })
-ns.RegisterPoints(MAPID, {
-    [56264118] = { -- Forgetful Apprentice's Tome
-        quest=70264,
-        loot={
-            198659, -- Forgetful Apprentice's Tome (+inscription)
-        },
-        note="Inscription",
-        vignette=5291,
-    },
-})
 
 -- Rares
 ns.RegisterPoints(MAPID, {


### PR DESCRIPTION
Added locations for one-time use profession skill-ups. Still need quest ids for most to mark them as complete.
The points are only visible on the maps if you have the required Dragonflight professions learned.